### PR TITLE
Add The 'Godep' Command As Image Entrypoint.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,3 +1,4 @@
 FROM golang:1.4.2
 ENV PATH $GOROOT/bin:$GOPATH/bin:$PATH
 RUN go get github.com/tools/godep
+ENTRYPOINT [ "godep" ]


### PR DESCRIPTION
This will set Godep as the image's main command. Now you can run your container with `docker run` as if you are running the Godep command directly. For example

``` sh
$ docker run --rm ribeirofelix/docker-golang-godep            # like godep
$ docker run --rm ribeirofelix/docker-golang-godep save       # like godep save
$ docker run --rm ribeirofelix/docker-golang-godep path       # like godep path
$ docker run --rm ribeirofelix/docker-golang-godep go build   # like godep go build
$ docker run --rm ribeirofelix/docker-golang-godep go save    # like godep go save
```
